### PR TITLE
Hotfix ci.yml

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,8 +27,8 @@ jobs:
   cd:
     runs-on: ubuntu-latest
     needs: [ci]
-    if: ${{ github.event.push }}
-
+    if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }} 
+        
     steps:
       - name: Checkout source code
         uses: actions/checkout@v2


### PR DESCRIPTION
Hotfix - change syntax of cd if clause to if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}

Resolves #78