### PR TITLE
Feature/add/security-relevant-headers

### DIFF
--- a/src/api/main.py
+++ b/src/api/main.py
@@ -32,13 +32,15 @@ app.add_middleware(CORSMiddleware, allow_origins=["*"])
 @app.middleware("http")
 async def add_security_headers(request: Request, call_next):
     response = await call_next(request)
-    
+
     response.headers["Cache-Control"] = "no-store"
     response.headers["Content-Type"] = "application/json"
     response.headers["Strict-Transport-Security"] = "max-age=63072000; preload"
     response.headers["X-Content-Type-Options"] = "nosniff"
     response.headers["X-Frame-Options"] = "DENY"
-    response.headers["Content-Security-Policy"] = "default-src 'none'; frame-ancestors 'none'"
+    response.headers[
+        "Content-Security-Policy"
+    ] = "default-src 'none'; frame-ancestors 'none'"
 
     # HTML-related (future-proof)
     response.headers["Feature-Policy"] = "'none'"


### PR DESCRIPTION
Implementing middleware to include following security-relevant headers in http responses:


- `Cache-Control: no-store`
- `Content-Security-Policy: default-src 'none'; frame-ancestors 'none'`
- `Content-Type`
- `Strict-Transport-Security`
- `X-Content-Type-Options: nosniff`
- `X-Frame-Options: DENY`
- `Feature-Policy: 'none'`
- `Referrer-Policy: no-referrer`

Fix #82 
