### PR TITLE
Remove content-type and content-security-policy

### DIFF
--- a/src/api/main.py
+++ b/src/api/main.py
@@ -34,13 +34,13 @@ async def add_security_headers(request: Request, call_next):
     response = await call_next(request)
 
     response.headers["Cache-Control"] = "no-store"
-    response.headers["Content-Type"] = "application/json"
+    #response.headers["Content-Type"] = "application/json"
     response.headers["Strict-Transport-Security"] = "max-age=63072000; preload"
     response.headers["X-Content-Type-Options"] = "nosniff"
     response.headers["X-Frame-Options"] = "DENY"
-    response.headers[
-        "Content-Security-Policy"
-    ] = "default-src 'none'; frame-ancestors 'none'"
+    #response.headers[
+    #    "Content-Security-Policy"
+    #] = "default-src 'none'; frame-ancestors 'none'"
 
     # HTML-related (future-proof)
     response.headers["Feature-Policy"] = "'none'"


### PR DESCRIPTION
Hotfix: Fixes the swagger-UI issue by removing two headers.

A more comprehensive fix with the headers added again and configured correctly will be added later.
