### PR TITLE
Feature/party donations backend

### DIFF
--- a/src/api/crud.py
+++ b/src/api/crud.py
@@ -564,23 +564,24 @@ def get_homepage_party_donations(db: Session):
             donation.date, date_8_years_ago_today
         )
 
-        #get year's quarter out of months
+        #Every year is 4 quarters, the remaining months can be calculated as quarters
         months = donation_time_from_beginning_of_range.months
-        quarter = 0
-        
+        additional_quarters = 0
+
         match months:
-            case months if months <= 3: quarter = 1
-            case months if months <= 6: quarter = 2
-            case months if months <= 9: quarter = 3
-            case months if months <= 2: quarter = 4
+            case months if months <= 2: additional_quarters = 0
+            case months if months >= 3 and months <= 5: additional_quarters = 1
+            case months if months >= 6 and months <= 8: additional_quarters = 2
+            case months if months >= 9: additional_quarters = 3
 
         donation_quarter_index = (
             donation_time_from_beginning_of_range.years * 4
-        ) + quarter
+        ) + additional_quarters
 
-        donations_over_32_quarters[donation.party_id][
-            donation_quarter_index
-        ] += donation.amount
+        donations_over_32_quarters[donation.party_id][donation_quarter_index] += donation.amount
+        if (donation.party_id) == 1:
+            print(str(donation.amount) + ":" + str(donation_time_from_beginning_of_range) + "/" + str(donation_quarter_index))
+
 
     for party in response_donation_data:
         party["donations_over_32_quarters"] = donations_over_32_quarters[party["id"]]

--- a/src/api/crud.py
+++ b/src/api/crud.py
@@ -579,9 +579,6 @@ def get_homepage_party_donations(db: Session):
         ) + additional_quarters
 
         donations_over_32_quarters[donation.party_id][donation_quarter_index] += donation.amount
-        if (donation.party_id) == 1:
-            print(str(donation.amount) + ":" + str(donation_time_from_beginning_of_range) + "/" + str(donation_quarter_index))
-
 
     for party in response_donation_data:
         party["donations_over_32_quarters"] = donations_over_32_quarters[party["id"]]

--- a/src/api/crud.py
+++ b/src/api/crud.py
@@ -541,11 +541,10 @@ def get_homepage_party_donations(db: Session):
             "party": None,
             "donations_over_32_quarters": [],
             "donations_total": 0,
-            "largest_quarter": None
+            "largest_quarter": None,
         }
         response_donation_data.append(data)
         donations_over_32_quarters[id] = [0] * 32
-
 
     # add party info to response
     # TODO: remove when db method of getting Bundestag parties is implemented
@@ -564,13 +563,13 @@ def get_homepage_party_donations(db: Session):
             donation.date, date_8_years_ago_today
         )
 
-        #Every year is 4 quarters, the remaining months can be calculated as quarters
+        # Every year is 4 quarters, the remaining months can be calculated as quarters
         months = donation_time_from_beginning_of_range.months
         additional_quarters = 0
 
         if months <= 2:
             additional_quarters = 0
-        elif months >= 3 and months <= 5: 
+        elif months >= 3 and months <= 5:
             additional_quarters = 1
         elif months >= 6 and months <= 8:
             additional_quarters = 2
@@ -581,7 +580,9 @@ def get_homepage_party_donations(db: Session):
             donation_time_from_beginning_of_range.years * 4
         ) + additional_quarters
 
-        donations_over_32_quarters[donation.party_id][donation_quarter_index] += donation.amount
+        donations_over_32_quarters[donation.party_id][
+            donation_quarter_index
+        ] += donation.amount
 
     for party in response_donation_data:
         party["donations_over_32_quarters"] = donations_over_32_quarters[party["id"]]

--- a/src/api/crud.py
+++ b/src/api/crud.py
@@ -568,11 +568,14 @@ def get_homepage_party_donations(db: Session):
         months = donation_time_from_beginning_of_range.months
         additional_quarters = 0
 
-        match months:
-            case months if months <= 2: additional_quarters = 0
-            case months if months >= 3 and months <= 5: additional_quarters = 1
-            case months if months >= 6 and months <= 8: additional_quarters = 2
-            case months if months >= 9: additional_quarters = 3
+        if months <= 2:
+            additional_quarters = 0
+        elif months >= 3 and months <= 5: 
+            additional_quarters = 1
+        elif months >= 6 and months <= 8:
+            additional_quarters = 2
+        else:
+            additional_quarters = 3
 
         donation_quarter_index = (
             donation_time_from_beginning_of_range.years * 4

--- a/src/api/schemas.py
+++ b/src/api/schemas.py
@@ -302,6 +302,7 @@ class PartyDonationOrganization(FTFBaseModel):
     donor_city: str
     donor_foreign: bool
 
+
 class PartyDonation(FTFBaseModel):
     id: int
     party: Party

--- a/src/api/schemas.py
+++ b/src/api/schemas.py
@@ -314,4 +314,4 @@ class HomepagePartyDonation(FTFBaseModel):
     party: Party
     donations_over_32_quarters: List[float]
     donations_total: float
-    largest_donation: float
+    largest_quarter: float

--- a/src/api/schemas.py
+++ b/src/api/schemas.py
@@ -302,7 +302,6 @@ class PartyDonationOrganization(FTFBaseModel):
     donor_city: str
     donor_foreign: bool
 
-
 class PartyDonation(FTFBaseModel):
     id: int
     party: Party
@@ -313,5 +312,6 @@ class PartyDonation(FTFBaseModel):
 
 class HomepagePartyDonation(FTFBaseModel):
     party: Party
-    donations_over_96_months: List[float]
+    donations_over_32_quarters: List[float]
     donations_total: float
+    largest_donation: float

--- a/tests/api/versions/test_v1.py
+++ b/tests/api/versions/test_v1.py
@@ -1014,5 +1014,5 @@ def test_read_homepage_party_donations():
 
     # not covered by schema
     for party in response_json:
-        assert len(party["donations_over_96_months"]) == 96
-        assert sum(party["donations_over_96_months"]) == party["donations_total"]
+        assert len(party["donations_over_32_quarters"]) == 32
+        assert sum(party["donations_over_32_quarters"]) == party["donations_total"]


### PR DESCRIPTION
This PR changes the donation dashboard response to be 32 quarterly donation groupings rather than 96 monthly donation groupings. It also adds the largest quarterly donation for each party to the response to help with scaling the charts on the front end. Tests were updated to accept these changes as well