### PR TITLE
Hotfix: Order sidejobs descending

### DIFF
--- a/src/api/crud.py
+++ b/src/api/crud.py
@@ -124,6 +124,7 @@ def get_sidejobs_by_politician_id(db: Session, id: int, version: str = "v2"):
                 == models.SidejobHasMandate.candidacy_mandate_id
             )
             .filter(models.SidejobHasMandate.sidejob_id == models.Sidejob.id)
+            .order_by(models.Sidejob.id.desc())
             .all()
         )
 


### PR DESCRIPTION
Problem: Order of sidejobs is mixed up for Politicians that have served multiple terms.
This PR changes the sidejobs query to get ordered desc.